### PR TITLE
Migrate to prop-types library

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "keywords": [
     "react-native"
   ],
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "devDependencies": {
     "@taw/condition-vsts": "^1.0.5",
     "babel-core": "^6.14.0",

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {View} from 'react-native';
 
@@ -6,13 +7,13 @@ import style from './style';
 export default class Cell extends Component {
 
     static propTypes = {
-        children: React.PropTypes.node,
-        rowId: React.PropTypes.number.isRequired,
-        id: React.PropTypes.number.isRequired
+        children: PropTypes.node,
+        rowId: PropTypes.number.isRequired,
+        id: PropTypes.number.isRequired
     };
 
     static contextTypes = {
-        rntgMeasureCell: React.PropTypes.func
+        rntgMeasureCell: PropTypes.func
     };
 
     updateCell(cell) {

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {View} from 'react-native';
 
@@ -6,12 +7,12 @@ import style from './style';
 export default class Grid extends Component {
 
     static propTypes = {
-        children: React.PropTypes.arrayOf(React.PropTypes.element).isRequired
+        children: PropTypes.arrayOf(PropTypes.element).isRequired
     };
 
     static childContextTypes = {
-        rntgAddRowToGrid: React.PropTypes.func,
-        rntgMeasureCell: React.PropTypes.func
+        rntgAddRowToGrid: PropTypes.func,
+        rntgMeasureCell: PropTypes.func
     };
 
     constructor() {

--- a/src/Row.js
+++ b/src/Row.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {View} from 'react-native';
 
@@ -6,16 +7,16 @@ import style from './style';
 export default class Row extends Component {
 
     static propTypes = {
-        children: React.PropTypes.arrayOf(React.PropTypes.element).isRequired,
-        id: React.PropTypes.number.isRequired
+        children: PropTypes.arrayOf(PropTypes.element).isRequired,
+        id: PropTypes.number.isRequired
     };
 
     static contextTypes = {
-        rntgAddRowToGrid: React.PropTypes.func
+        rntgAddRowToGrid: PropTypes.func
     };
 
     static childContextTypes = {
-        rntgrowId: React.PropTypes.number
+        rntgrowId: PropTypes.number
     };
 
     getChildContext() {


### PR DESCRIPTION
`React.PropTypes` [is deprecated as of React v15.5](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes). This migrates to the `prop-types` library, which should have no functional consequences.

See also https://github.com/Benjamin-Dobell/react-native-markdown-view/pull/4.