### PR TITLE
Use new Context API

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,11 @@
       "email": "contact@glassechidna.com.au"
     }
   ],
-  "files": [
-    "src"
-  ],
+  "files": ["src"],
   "main": "src/index.js",
-  "keywords": [
-    "react-native"
-  ],
+  "keywords": ["react-native"],
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@taw/condition-vsts": "^1.0.5",
@@ -43,7 +39,7 @@
     "semantic-release": "^6.3.2"
   },
   "peerDependencies": {
-    "react": ">=15.4.2",
+    "react": ">=16.3.0",
     "react-native": ">=0.41.0"
   },
   "scripts": {
@@ -54,24 +50,12 @@
   },
   "jest": {
     "collectCoverage": true,
-    "coverageReporters": [
-      "lcov",
-      "cobertura",
-      "text"
-    ],
+    "coverageReporters": ["lcov", "cobertura", "text"],
     "setupTestFrameworkScriptFile": "jestSupport/setupJasmine.js",
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/example/"
-    ],
+    "testPathIgnorePatterns": ["<rootDir>/node_modules/", "<rootDir>/example/"],
     "automock": true,
-    "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "jsx"
-    ]
+    "unmockedModulePathPatterns": ["<rootDir>/node_modules/"],
+    "moduleFileExtensions": ["js", "jsx"]
   },
   "release": {
     "branch": "master",

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -1,32 +1,32 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
-import {View} from 'react-native';
+import React, { Component } from 'react';
+import { View } from 'react-native';
 
 import style from './style';
 
 export default class Cell extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    rowId: PropTypes.number.isRequired,
+    id: PropTypes.number.isRequired
+  };
 
-    static propTypes = {
-        children: PropTypes.node,
-        rowId: PropTypes.number.isRequired,
-        id: PropTypes.number.isRequired
-    };
+  static contextTypes = {
+    rntgMeasureCell: PropTypes.func
+  };
 
-    static contextTypes = {
-        rntgMeasureCell: PropTypes.func
-    };
+  updateCell(cell) {
+    cell &&
+      cell.measure((x, y, w, h) => {
+        this.context.rntgMeasureCell(this.props.rowId, this.props.id, x, y, w, h);
+      });
+  }
 
-    updateCell(cell) {
-        cell && cell.measure((x, y, w, h) => {
-            this.context.rntgMeasureCell(this.props.rowId, this.props.id, x, y, w, h);
-        });
-    }
-
-    render() {
-        return (
-            <View style={[style.cell, this.props.style]} ref={this.updateCell.bind(this)}>
-                {this.props.children}
-            </View>
-        );
-    }
+  render() {
+    return (
+      <View style={[style.cell, this.props.style]} ref={this.updateCell.bind(this)}>
+        {this.props.children}
+      </View>
+    );
+  }
 }

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -2,31 +2,31 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
+import GridContext from './GridContext';
 import style from './style';
 
-export default class Cell extends Component {
-  static propTypes = {
-    children: PropTypes.node,
-    rowId: PropTypes.number.isRequired,
-    id: PropTypes.number.isRequired
-  };
+const Cell = props => (
+  <GridContext.Consumer>
+    {({ measureCell }) => {
+      return (
+        <View
+          style={[style.cell, props.style]}
+          onLayout={({ nativeEvent }) => {
+            const { x, y, width, height } = nativeEvent.layout;
+            measureCell(props.rowId, props.id, x, y, width, height);
+          }}
+        >
+          {props.children}
+        </View>
+      );
+    }}
+  </GridContext.Consumer>
+);
 
-  static contextTypes = {
-    rntgMeasureCell: PropTypes.func
-  };
+Cell.propTypes = {
+  children: PropTypes.node,
+  rowId: PropTypes.number.isRequired,
+  id: PropTypes.number.isRequired
+};
 
-  updateCell(cell) {
-    cell &&
-      cell.measure((x, y, w, h) => {
-        this.context.rntgMeasureCell(this.props.rowId, this.props.id, x, y, w, h);
-      });
-  }
-
-  render() {
-    return (
-      <View style={[style.cell, this.props.style]} ref={this.updateCell.bind(this)}>
-        {this.props.children}
-      </View>
-    );
-  }
-}
+export default Cell;

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -6,27 +6,24 @@ import GridContext from './GridContext';
 import style from './style';
 
 const Cell = props => (
-  <GridContext.Consumer>
-    {({ measureCell }) => {
-      return (
-        <View
-          style={[style.cell, props.style]}
-          onLayout={({ nativeEvent }) => {
-            const { x, y, width, height } = nativeEvent.layout;
-            measureCell(props.rowId, props.id, x, y, width, height);
-          }}
-        >
-          {props.children}
-        </View>
-      );
-    }}
-  </GridContext.Consumer>
+    <GridContext.Consumer>
+        {({ measureCell }) => (
+            <View
+                style={[style.cell, props.style]}
+                onLayout={({ nativeEvent }) => {
+                    measureCell(props.rowId, props.id, nativeEvent.layout.height);
+                }}
+            >
+                {props.children}
+            </View>
+        )}
+    </GridContext.Consumer>
 );
 
 Cell.propTypes = {
-  children: PropTypes.node,
-  rowId: PropTypes.number.isRequired,
-  id: PropTypes.number.isRequired
+    children: PropTypes.node,
+    rowId: PropTypes.number.isRequired,
+    id: PropTypes.number.isRequired
 };
 
 export default Cell;

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -1,111 +1,90 @@
+import React from 'react';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
-import {View} from 'react-native';
-
+import GridContext from './GridContext';
 import style from './style';
 
-export default class Grid extends Component {
+export default class GridProvider extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.arrayOf(PropTypes.element).isRequired
+  };
 
-    static propTypes = {
-        children: PropTypes.arrayOf(PropTypes.element).isRequired
-    };
+  columns = [];
+  rowHeights = {};
 
-    static childContextTypes = {
-        rntgAddRowToGrid: PropTypes.func,
-        rntgMeasureCell: PropTypes.func
-    };
+  state = {
+    columns: [],
+    rowHeights: {}
+  };
 
-    constructor() {
-        super(...arguments);
-        this.columns = [];
-        this.rowHeights = {};
+  get lastChild() {
+    return this.props.children[this.props.children.length - 1];
+  }
+
+  addRowToGrid = (rowId, rowChildren) => {
+    this.mapRowIntoColumns(rowChildren);
+    this.updateIfRowIsLast(rowId);
+  };
+
+  measureCell = (rowId, cellId, x, y, w, h) => {
+    this.rowHeights[rowId] = Math.max(h, this.rowHeights[rowId] || 0);
+    this.updateIfCellIsLast(rowId, cellId);
+  };
+
+  mapRowIntoColumns(rowChildren) {
+    rowChildren.forEach((cell, index) => {
+      if (!this.columns[index]) {
+        this.columns[index] = [];
+      }
+      this.columns[index].push(cell);
+    });
+  }
+
+  updateIfRowIsLast(rowId) {
+    // If we have all rows, save the column structure into 'state' so
+    // That we can render it
+    if (rowId === this.lastChild.props.id) {
+      this.setState({
+        columns: this.columns
+      });
     }
+  }
 
-    getChildContext() {
-        return {
-            rntgAddRowToGrid: this.addRowToGrid.bind(this),
-            rntgMeasureCell: this.measureCell.bind(this)
-        };
-    }
-
-    shouldComponentUpdate(nextProps, nextState) {
-        if (nextState) {
-            if (!this.state || Object.keys(nextState).join('.') !== Object.keys(this.state).join('.')) {
-                return true;
-            }
-            if (nextState.rowHeights) {
-                for (let rowId of Object.keys(nextState.rowHeights)) {
-                    if (nextState.rowHeights[rowId] !== this.state.rowHeights[rowId]) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    get lastChild() {
-        return this.props.children[this.props.children.length-1];
-    }
-
-    addRowToGrid(row) {
-        this.mapRowIntoColumns(row);
-        this.updateIfRowIsLast(row);
-    }
-
-    measureCell(rowId, cellId, x, y, w, h) {
-        this.rowHeights[rowId] = Math.max(h, this.rowHeights[rowId]||0);
-        this.updateIfCellIsLast(rowId, cellId);
-    }
-
-    mapRowIntoColumns(row) {
-        row.props.children.forEach((cell, index) => {
-            if (!this.columns[index]) {
-                this.columns[index] = [];
-            }
-            this.columns[index].push(cell);
+  updateIfCellIsLast(rowId, cellId) {
+    if (rowId === this.lastChild.props.id) {
+      const lastCell = this.lastChild.props.children[this.lastChild.props.children.length - 1];
+      if (cellId === lastCell.props.id) {
+        this.setState({
+          rowHeights: { ...this.rowHeights }
         });
+      }
     }
+  }
 
-    updateIfRowIsLast(row) {
-        //if we have all rows, save the column structure into 'state' so
-        //that we can render it
-        if (row.props.id === this.lastChild.props.id) {
-            this.setState({
-                columns: this.columns
-            });
-        }
+  renderContent = () => {
+    if (this.columns.length === 0) {
+      return <View style={style.grid}>{this.props.children}</View>;
     }
-
-    updateIfCellIsLast(rowId, cellId) {
-        if (rowId === this.lastChild.props.id) {
-            const lastCell = this.lastChild.props.children[this.lastChild.props.children.length-1];
-            if (cellId === lastCell.props.id) {
-                this.setState({
-                    rowHeights: {...this.rowHeights}
-                });
-            }
-        }
-    }
-
-    render() {
-        if (!this.columns.length) {
-            return <View style={style.grid}>{this.props.children}</View>;
-        }
-        return (
-            <View style={[style.grid, style.gridColumn, this.props.style]}>
-            {this.columns.map((col, i) => (
-                <View key={i} style={[style.column]}>
-                {col.map((cell, index) => (
-                    <View key={index} style={[
-                        {minHeight: this.state.rowHeights && this.state.rowHeights[index+1]}
-                    ]}>
-                        {cell}
-                    </View>
-                ))}
-                </View>
+    return (
+      <View style={[style.grid, style.gridColumn, this.props.style]}>
+        {this.columns.map((col, i) => (
+          <View key={i} style={style.column}>
+            {col.map((cell, index) => (
+              <View key={index} style={[{ minHeight: this.state.rowHeights && this.state.rowHeights[index + 1] }]}>
+                {cell}
+              </View>
             ))}
-            </View>
-        );
-    }
+          </View>
+        ))}
+      </View>
+    );
+  };
+
+  render() {
+    return (
+      <GridContext.Provider value={{ addRowToGrid: this.addRowToGrid, measureCell: this.measureCell }}>
+        {this.renderContent()}
+      </GridContext.Provider>
+    );
+  }
 }

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -28,10 +28,12 @@ export default class GridProvider extends React.PureComponent {
   componentDidUpdate() {
       // Force redraw to update column measurements
       if (this.state.redraw) {
-          this.setState({
-              redraw: false,
-              didRedraw: true
-          });
+          setTimeout(() => {
+              this.setState({
+                  redraw: false,
+                  didRedraw: true
+              });
+          }, 100);
       }
   }
 

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -75,8 +75,6 @@ export default class GridProvider extends React.PureComponent {
   renderContent = () => {
       const { rowHeights, columns } = this.state;
 
-      // console.log('rowHeights', rowHeights, 'columns', columns);
-
       if (columns.length === 0) {
           return <View style={style.grid}>{this.props.children}</View>;
       }

--- a/src/GridContext.js
+++ b/src/GridContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const GridContext = React.createContext();
+
+export default GridContext;

--- a/src/Row.js
+++ b/src/Row.js
@@ -1,35 +1,21 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
-import {View} from 'react-native';
-
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import GridContext from './GridContext';
 import style from './style';
 
-export default class Row extends Component {
+const Row = ({ id, children }) => (
+  <GridContext.Consumer>
+    {({ addRowToGrid }) => {
+      addRowToGrid(id, children);
+      return <View style={style.row}>{children}</View>;
+    }}
+  </GridContext.Consumer>
+);
 
-    static propTypes = {
-        children: PropTypes.arrayOf(PropTypes.element).isRequired,
-        id: PropTypes.number.isRequired
-    };
+Row.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  id: PropTypes.number.isRequired
+};
 
-    static contextTypes = {
-        rntgAddRowToGrid: PropTypes.func
-    };
-
-    static childContextTypes = {
-        rntgrowId: PropTypes.number
-    };
-
-    getChildContext() {
-        return {
-            rntgrowId: this.props.id
-        };
-    }
-
-    componentWillMount() {
-        this.context.rntgAddRowToGrid(this);
-    }
-
-    render() {
-        return <View style={style.row}>{this.props.children}</View>;
-    }
-}
+export default Row;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-export {default as Grid} from './Grid';
-export {default as Row} from './Row';
-export {default as Cell} from './Cell';
+export { default as Grid } from './Grid';
+export { default as Row } from './Row';
+export { default as Cell } from './Cell';


### PR DESCRIPTION
Changes:
- Uses React 16.3's Context API
- Cells and Rows are Presentational components as they don't need to hook in to the component lifecycle
- Grid is a PureComponent; a shallow diff should be sufficient for a re-render
- Cells now use "onLayout" to calculate x, y, width height instead of "ref" which should improve render performance
- Fixes an issue with current React Native where the console would be spammed with "isMounted() is deprecated" warnings on every ref update.